### PR TITLE
Make installation instructions more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ analysis on the comments community members make on others' contributions.
 
 ## Install
 
+Clone the repository, change to the directory containing the repository.
+
 ```bash
 $ pip install -r requirements.txt
 ```


### PR DESCRIPTION
For non-python programmers unfamiliar with pip it can take a moment to realize that the requirements.txt file is local to the repository, not a general pip thing. This makes it explicit.

If this is too forehead-slappingly obvious I will not be offended or in any way disappointed if you close this without merging :heart: