### PR TITLE
requirements.txt: Return statistics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ pytz==2016.7
 requests==2.11.1
 scipy==0.18.1
 six==1.10.0
+statistics==1.0.3.5; python_version < '3.4'
 uritemplate==3.0.0
 uritemplate.py==3.0.2


### PR DESCRIPTION
`ghstats.py` requires statistics in order to run. This requirement was
originally featured in `requirements.txt`, but was removed by commit
3a79f8. That removal seems to be a mistake, as requiring statistics
do not harm the functionality of `ghrusthighfive.py` that commit
introduced, and it's clearly needed by `ghstats.py`.

This patch returns the statistics requirement in order to unbreak
`ghstats.py`.