### PR TITLE
Add installation/troubleshooting suggestion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Clone the repository, change to the directory containing the repository.
 $ pip install -r requirements.txt
 ```
 
-May require `sudo`.
+May require `sudo`. If `sudo` fails, try passing the `--user` flag.
 
 ## Install Stanford CoreNLP
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ analysis on the comments community members make on others' contributions.
 
 ## Install
 
+If you don't have Python installed, follow the instructions in the
+[Django Girls installation guide](https://tutorial.djangogirls.org/en/python_installation/).
+
 Clone the repository, change to the directory containing the repository.
 
 ```bash


### PR DESCRIPTION
For people who don't do development in Python on a regular basis, their
development environment is likely woefully outdated, and dependency
management is tricky.

The shotgun approach to installation failures tends to apply.
This gives people an extra thing to try that might work.