### PR TITLE
Add note about statistics dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ $ python ghcategorize.py GITHUB_REPO_NAME GITHUB_OWNER_NAME
 
 ### Stats
 
+You will need the `statistics` module to generate stats. If you have Python
+3.4 or newer, you're fine, as it ships with this module. If you have an older
+version of Python you can install it with pip:
+
+```bash
+pip install statistics
+```
+
 Then generate html reports with statistics (note this imports functions from ghreport.py)
 
 ```bash


### PR DESCRIPTION
Non-python devs might not have a recent version of Python that ships with statistics.
This clarifies how to install as a separate dependency on older versions
of Python.